### PR TITLE
Fix introspection key

### DIFF
--- a/src/main/java/wuxiacraft/client/InputHandler.java
+++ b/src/main/java/wuxiacraft/client/InputHandler.java
@@ -26,10 +26,8 @@ public class InputHandler {
 
 	@SubscribeEvent
 	public static void onKeyPressed(InputEvent.KeyInputEvent event) {
-		if(event.getAction() == 0) {
-			if (event.getKey() == GLFW.GLFW_KEY_K) {
-				WuxiaPacketHandler.INSTANCE.sendToServer(new OpenScreenMessage(OpenScreenMessage.ScreenType.INTROSPECTION));
-			}
+		if (mappings.get(OPEN_INTROSPECTION).consumeClick()) {
+			WuxiaPacketHandler.INSTANCE.sendToServer(new OpenScreenMessage(OpenScreenMessage.ScreenType.INTROSPECTION));
 		}
 	}
 


### PR DESCRIPTION
Set introspection key to use the mapping properly
Fixes bug where pressing the key in chat or escape menu opens the introspection menu